### PR TITLE
Limit camelCasing to just the cap'n'p files

### DIFF
--- a/procession/schemas/change-get-1.0.json
+++ b/procession/schemas/change-get-1.0.json
@@ -4,7 +4,7 @@
     "title": "A single change within a changeset.",
     "additionalProperties": false,
     "properties": {
-        "changesetId": {
+        "changeset_id": {
             "type": "string",
             "description": "Identifier for the changeset."
         },
@@ -12,12 +12,12 @@
             "type": "integer",
             "description": "Sequence number of the patch within the changeset."
         },
-        "createdOn": {
+        "created_on": {
             "type": "string",
             "description": "The date-time when the change was created, in ISO 8601 format.",
             "format": "date-time"
         },
-        "uploadedBy": {
+        "uploaded_by": {
             "type": "string",
             "description": "Identifier of the user who originally uploaded the change."
         }

--- a/procession/schemas/change-getmany-1.0.json
+++ b/procession/schemas/change-getmany-1.0.json
@@ -4,7 +4,7 @@
     "title": "A single change within a changeset.",
     "additionalProperties": false,
     "properties": {
-        "changesetId": {
+        "changeset_id": {
             "type": "integer",
             "description": "Identifier for the changeset."
         },
@@ -12,12 +12,12 @@
             "type": "integer",
             "description": "Sequence number of the patch within the changeset."
         },
-        "createdOn": {
+        "created_on": {
             "type": "string",
             "description": "The date-time when the organization was created, in ISO 8601 format.",
             "format": "date-time"
         },
-        "uploadedBy": {
+        "uploaded_by": {
             "type": "integer",
             "description": "Identifier of the user who originally uploaded the change."
         }

--- a/procession/schemas/change-post-1.0.json
+++ b/procession/schemas/change-post-1.0.json
@@ -4,10 +4,10 @@
     "title": "A single change within a changeset.",
     "additionalProperties": false,
     "required": [
-        "changesetId"
+        "changeset_id"
     ],
     "properties": {
-        "changesetId": {
+        "changeset_id": {
             "type": "string",
             "description": "Identifier for the changeset."
         }

--- a/procession/schemas/changeset-get-1.0.json
+++ b/procession/schemas/changeset-get-1.0.json
@@ -8,24 +8,24 @@
             "type": "string",
             "description": "Identifier for the changeset."
         },
-        "targetRepoId": {
+        "target_repo_id": {
             "type": "string",
             "description": "Identifier for the target repository."
         },
-        "targetBranch": {
+        "target_branch": {
             "type": "string",
             "description": "Name of the SCM branch that the changeset intends to merge into."
         },
-        "createdOn": {
+        "created_on": {
             "type": "string",
             "description": "The date-time when the changeset was created, in ISO 8601 format.",
             "format": "date-time"
         },
-        "uploadedBy": {
+        "uploaded_by": {
             "type": "string",
             "description": "Identifier of the user who originally uploaded the changeset."
         },
-        "commitMessage": {
+        "commit_message": {
             "type": "string",
             "description": "The commit message that will be used when the changeset is merged into the target branch."
         },

--- a/procession/schemas/changeset-getmany-1.0.json
+++ b/procession/schemas/changeset-getmany-1.0.json
@@ -8,24 +8,24 @@
             "type": "string",
             "description": "Identifier for the changeset."
         },
-        "targetRepoId": {
+        "target_repo_id": {
             "type": "string",
             "description": "Identifier for the target repository."
         },
-        "targetBranch": {
+        "target_branch": {
             "type": "string",
             "description": "Name of the SCM branch that the changeset intends to merge into."
         },
-        "createdOn": {
+        "created_on": {
             "type": "string",
             "description": "The date-time when the changeset was created, in ISO 8601 format.",
             "format": "date-time"
         },
-        "uploadedBy": {
+        "uploaded_by": {
             "type": "string",
             "description": "Identifier of the user who originally uploaded the changeset."
         },
-        "commitMessage": {
+        "commit_message": {
             "type": "string",
             "description": "The commit message that will be used when the changeset is merged into the target branch."
         },

--- a/procession/schemas/changeset-post-1.0.json
+++ b/procession/schemas/changeset-post-1.0.json
@@ -4,20 +4,20 @@
     "title": "A series of proposed changes to a repository.",
     "additionalProperties": false,
     "required": [
-        "targetRepoId",
-        "targetBranch",
+        "target_repo_id",
+        "target_branch",
         "commitMessage"
     ],
     "properties": {
-        "targetRepoId": {
+        "target_repo_id": {
             "type": "integer",
             "description": "Identifier for the target repository."
         },
-        "targetBranch": {
+        "target_branch": {
             "type": "string",
             "description": "Name of the SCM branch that the changeset intends to merge into."
         },
-        "commitMessage": {
+        "commit_message": {
             "type": "string",
             "description": "The commit message that will be used when the changeset is merged into the target branch."
         }

--- a/procession/schemas/domain-get-1.0.json
+++ b/procession/schemas/domain-get-1.0.json
@@ -16,12 +16,12 @@
             "type": "string",
             "description": "Lowercased, hyphenated non-UUID identififer used in URIs."
         },
-        "createdOn": {
+        "created_on": {
             "type": "string",
             "description": "The date-time when the organization was created, in ISO 8601 format.",
             "format": "date-time"
         },
-        "ownerId": {
+        "owner_id": {
             "type": "integer",
             "description": "Identifier for the user who owns the domain."
         },

--- a/procession/schemas/domain-getmany-1.0.json
+++ b/procession/schemas/domain-getmany-1.0.json
@@ -16,12 +16,12 @@
             "type": "string",
             "description": "Lowercased, hyphenated non-UUID identififer used in URIs."
         },
-        "createdOn": {
+        "created_on": {
             "type": "string",
             "description": "The date-time when the organization was created, in ISO 8601 format.",
             "format": "date-time"
         },
-        "ownerId": {
+        "owner_id": {
             "type": "integer",
             "description": "Identifier for the user who owns the domain."
         },

--- a/procession/schemas/domain-post-1.0.json
+++ b/procession/schemas/domain-post-1.0.json
@@ -6,14 +6,14 @@
     "required": [
         "name",
         "visibility",
-        "ownerId"
+        "owner_id"
     ],
     "properties": {
         "name": {
             "type": "string",
             "description": "Name for the domain (used in determining the user's 'slug' value)."
         },
-        "ownerId": {
+        "owner_id": {
             "type": "integer",
             "description": "Identifier for the user who owns the domain."
         },

--- a/procession/schemas/domain-put-1.0.json
+++ b/procession/schemas/domain-put-1.0.json
@@ -8,7 +8,7 @@
             "type": "string",
             "description": "Name for the domain (used in determining the user's 'slug' value)."
         },
-        "ownerId": {
+        "owner_id": {
             "type": "integer",
             "description": "Identifier for the user who owns the domain."
         },

--- a/procession/schemas/group-get-1.0.json
+++ b/procession/schemas/group-get-1.0.json
@@ -16,11 +16,11 @@
             "type": "string",
             "description": "Lowercased, hyphenated non-UUID identififer used in URIs."
         },
-        "rootOrganizationId": {
+        "root_organization_id": {
             "type": "string",
             "description": "The ID of the root organization of the organization tree that this group belongs to."
         },
-        "createdOn": {
+        "created_on": {
             "type": "string",
             "description": "The date-time when the organization was created, in ISO 8601 format.",
             "format": "date-time"

--- a/procession/schemas/group-getmany-1.0.json
+++ b/procession/schemas/group-getmany-1.0.json
@@ -16,11 +16,11 @@
             "type": "string",
             "description": "Lowercased, hyphenated non-UUID identififer used in URIs."
         },
-        "rootOrganizationId": {
+        "root_organization_id": {
             "type": "string",
             "description": "The ID of the root organization of the organization tree that this group belongs to."
         },
-        "createdOn": {
+        "created_on": {
             "type": "string",
             "description": "The date-time when the organization was created, in ISO 8601 format.",
             "format": "date-time"

--- a/procession/schemas/group-post-1.0.json
+++ b/procession/schemas/group-post-1.0.json
@@ -5,14 +5,14 @@
     "additionalProperties": false,
     "required": [
         "name",
-        "rootOrganizationId"
+        "root_organization_id"
     ],
     "properties": {
         "name": {
             "type": "string",
             "description": "Name for the group (used in determining the group's 'slug' value). Must be unique within the containing organization."
         },
-        "rootOrganizationId": {
+        "root_organization_id": {
             "type": "string",
             "description": "The ID of the root organization of the organization tree that this group belongs to."
         }

--- a/procession/schemas/group-put-1.0.json
+++ b/procession/schemas/group-put-1.0.json
@@ -5,14 +5,14 @@
     "additionalProperties": false,
     "required": [
         "name",
-        "rootOrganizationId"
+        "root_organization_id"
     ],
     "properties": {
         "name": {
             "type": "string",
             "description": "Name for the group (used in determining the group's 'slug' value). Must be unique within the containing organization."
         },
-        "rootOrganizationId": {
+        "root_organization_id": {
             "type": "string",
             "description": "The ID of the root organization of the organization tree that this group belongs to."
         }

--- a/procession/schemas/repository-get-1.0.json
+++ b/procession/schemas/repository-get-1.0.json
@@ -8,7 +8,7 @@
             "type": "integer",
             "description": "Identifier for the repository."
         },
-        "domainId": {
+        "domain_id": {
             "type": "integer",
             "description": "Identifier for the domain."
         },
@@ -16,12 +16,12 @@
             "type": "string",
             "description": "Name for the repository. Must be unique within the domain."
         },
-        "createdOn": {
+        "created_on": {
             "type": "string",
             "description": "The date-time when the repository was created, in ISO 8601 format.",
             "format": "date-time"
         },
-        "ownerId": {
+        "owner_id": {
             "type": "integer",
             "description": "Identifier for the user who owns the repository."
         }

--- a/procession/schemas/repository-getmany-1.0.json
+++ b/procession/schemas/repository-getmany-1.0.json
@@ -8,7 +8,7 @@
             "type": "integer",
             "description": "Identifier for the repository."
         },
-        "domainId": {
+        "domain_id": {
             "type": "integer",
             "description": "Identifier for the domain."
         },
@@ -16,12 +16,12 @@
             "type": "string",
             "description": "Name for the repository. Must be unique within the domain."
         },
-        "createdOn": {
+        "created_on": {
             "type": "string",
             "description": "The date-time when the repository was created, in ISO 8601 format.",
             "format": "date-time"
         },
-        "ownerId": {
+        "owner_id": {
             "type": "integer",
             "description": "Identifier for the user who owns the repository."
         }

--- a/procession/schemas/repository-post-1.0.json
+++ b/procession/schemas/repository-post-1.0.json
@@ -4,12 +4,12 @@
     "title": "An SCM repository under Procession's control.",
     "additionalProperties": false,
     "required": [
-        "domainId",
+        "domain_id",
         "name",
-        "ownerId"
+        "owner_id"
     ],
     "properties": {
-        "domainId": {
+        "domain_id": {
             "type": "integer",
             "description": "Identifier for the domain."
         },
@@ -17,7 +17,7 @@
             "type": "string",
             "description": "Name for the repository. Must be unique within the domain."
         },
-        "ownerId": {
+        "owner_id": {
             "type": "integer",
             "description": "Identifier for the user who owns the repository."
         }

--- a/procession/schemas/repository-put-1.0.json
+++ b/procession/schemas/repository-put-1.0.json
@@ -4,7 +4,7 @@
     "title": "An SCM repository under Procession's control.",
     "additionalProperties": false,
     "properties": {
-        "domainId": {
+        "domain_id": {
             "type": "integer",
             "description": "Identifier for the domain."
         },
@@ -12,7 +12,7 @@
             "type": "string",
             "description": "Name for the repository. Must be unique within the domain."
         },
-        "ownerId": {
+        "owner_id": {
             "type": "integer",
             "description": "Identifier for the user who owns the repository."
         }

--- a/procession/schemas/user_public_key-get-1.0.json
+++ b/procession/schemas/user_public_key-get-1.0.json
@@ -4,7 +4,7 @@
     "title": "An SSH key pair for a user.",
     "additionalProperties": false,
     "properties": {
-        "userId": {
+        "user_id": {
             "type": "integer",
             "description": "Identifier for the user."
         },
@@ -14,11 +14,11 @@
             "minLength": 32,
             "maxLength": 40
         },
-        "publicKey": {
+        "public_key": {
             "type": "string",
             "description": "Public key part of SSH key pair."
         },
-        "createdOn": {
+        "created_on": {
             "type": "string",
             "description": "The date-time when the key was created, in ISO 8601 format.",
             "format": "date-time"

--- a/procession/schemas/user_public_key-getmany-1.0.json
+++ b/procession/schemas/user_public_key-getmany-1.0.json
@@ -4,7 +4,7 @@
     "title": "An SSH key pair for a user.",
     "additionalProperties": false,
     "properties": {
-        "userId": {
+        "user_id": {
             "type": "integer",
             "description": "Identifier for the user."
         },
@@ -14,11 +14,11 @@
             "minLength": 32,
             "maxLength": 40
         },
-        "publicKey": {
+        "public_key": {
             "type": "string",
             "description": "Public key part of SSH key pair."
         },
-        "createdOn": {
+        "created_on": {
             "type": "string",
             "description": "The date-time when the key was created, in ISO 8601 format.",
             "format": "date-time"

--- a/procession/schemas/user_public_key-post-1.0.json
+++ b/procession/schemas/user_public_key-post-1.0.json
@@ -4,15 +4,15 @@
     "title": "An SSH key pair for a user.",
     "additionalProperties": false,
     "required": [
-        "userId",
-        "publicKey"
+        "user_id",
+        "public_key"
     ],
     "properties": {
-        "userId": {
+        "user_id": {
             "type": "integer",
             "description": "Identifier for the user."
         },
-        "publicKey": {
+        "public_key": {
             "type": "string",
             "description": "Public key part of SSH key pair."
         }

--- a/procession/schemas/user_public_key-put-1.0.json
+++ b/procession/schemas/user_public_key-put-1.0.json
@@ -4,15 +4,15 @@
     "title": "An SSH key pair for a user.",
     "additionalProperties": false,
     "required": [
-        "userId",
-        "publicKey"
+        "user_id",
+        "public_key"
     ],
     "properties": {
-        "userId": {
+        "user_id": {
             "type": "integer",
             "description": "Identifier for the user."
         },
-        "publicKey": {
+        "public_key": {
             "type": "string",
             "description": "Public key part of SSH key pair."
         }

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -64,4 +64,4 @@ class TestOrganizations(base.UnitTest):
                                 })
         obj = objects.Organization.from_http_req(req)
         self.assertEqual('My org', obj.name)
-        self.assertEqual(six.b(''), obj.parentOrganizationId)
+        self.assertEqual(six.b(''), obj.parent_organization_id)


### PR DESCRIPTION
It was really annoying to have to use camelCasing for attributes on the
object models just because cap'n'p forces you to use camelCasing, even
when Python's standard conventions are to use under_score_names. This
patch changes the base object model attributes to be under_score_names
and adds a thin translation layer for when the Cap'n'p message objects
need to be set/get.