### PR TITLE
Adds some unit tests for base object methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.coverage*
 cover
 .testrepository
 *.py[cod]

--- a/procession/objects.py
+++ b/procession/objects.py
@@ -102,7 +102,7 @@ class Object(object):
     """
 
     _TIMESTAMP_FIELD_TRANSLATIONS = [
-        'createdOn',
+        'created_on',
     ]
     """
     List of names of any fields that should automatically have
@@ -152,7 +152,7 @@ class Object(object):
         """
         result = {}
         for k, v in values.items():
-            tx_key = cls._FIELD_NAME_TRANSLATIONS.get(k, k)
+            tx_key = cls._get_capnp_field_name(k)
             result[tx_key] = v
         return result
 
@@ -255,6 +255,7 @@ class Object(object):
         for field in cls._NULLSTRING_FIELD_TRANSLATIONS:
             if field in subject and subject[field] is None:
                 subject[field] = ''
+        subject = cls.field_names_to_capnp(subject)
         return cls(cls._CAPNP_OBJECT.new_message(**subject), ctx=ctx)
 
     @classmethod

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -14,21 +14,23 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+import datetime
 import json
+import mock
+import tempfile
 
 import falcon
 from falcon.testing import helpers
-import six
 import testtools
 
+from procession import context
 from procession import exc
 from procession import objects
-from procession.rest import version as rversion
 
 from tests import base
 
 
-class TestOrganizations(base.UnitTest):
+class TestObjects(base.UnitTest):
 
     @staticmethod
     def _get_request(**kwargs):
@@ -36,32 +38,61 @@ class TestOrganizations(base.UnitTest):
         env['procession.ctx'] = 'ctx'
         return falcon.Request(env)
 
-    def test_organization(self):
-        obj = objects.Organization.from_values(name='funky')
-        self.assertIsInstance(obj, objects.Object)
+    def test_from_dict(self):
+        values = {
+            'name': 'funky',
+            'created_on': datetime.datetime.utcnow(),
+        }
+        obj = objects.Organization.from_dict(values)
+        self.assertIsInstance(obj, objects.Organization)
         self.assertEqual(obj.name, 'funky')
 
-    def test_organization_rest_v1_0(self):
-        version = "1.0"
+    def test_from_values(self):
+        obj = objects.Organization.from_values(name='funky')
+        self.assertIsInstance(obj, objects.Organization)
+        self.assertEqual(obj.name, 'funky')
+
+    def test_from_capnp(self):
+        org_capnp = objects.organization_capnp.Organization
+        org_message = org_capnp.new_message(name='funky')
+        with tempfile.NamedTemporaryFile() as msg_file:
+            org_message.write(msg_file)
+            obj = objects.Organization.from_capnp(open(msg_file.name, 'rb'))
+        self.assertIsInstance(obj, objects.Organization)
+        self.assertEqual(obj.name, 'funky')
+
+    def test_from_http_req_400(self):
         obj_dict = {
             # Missing required name attribute...
         }
-        req = self._get_request(method='POST',
-                                body=json.dumps(obj_dict),
-                                headers={
-                                    rversion.VERSION_HEADER: version
-                                })
+        req = self._get_request(method='POST', body=json.dumps(obj_dict))
         with testtools.ExpectedException(exc.BadInput):
             objects.Organization.from_http_req(req)
 
+    def test_from_http_req(self):
         obj_dict = {
             'name': 'My org',
         }
-        req = self._get_request(method='POST',
-                                body=json.dumps(obj_dict),
-                                headers={
-                                    rversion.VERSION_HEADER: version
-                                })
+        req = self._get_request(method='POST', body=json.dumps(obj_dict))
         obj = objects.Organization.from_http_req(req)
         self.assertEqual('My org', obj.name)
-        self.assertEqual(six.b(''), obj.parent_organization_id)
+
+    def test_from_http_req_with_overrides(self):
+        obj_dict = {
+            'name': 'My org',
+        }
+        req = self._get_request(method='POST', body=json.dumps(obj_dict))
+        obj = objects.Organization.from_http_req(req, name='funky')
+        self.assertEqual('funky', obj.name)
+
+    def test_get_by_key_with_ctx(self):
+        obj_dict = {
+            'name': 'My org',
+        }
+        ctx = context.Context()
+        ctx.store = mock.MagicMock()
+        ctx.store.get_one.return_value = obj_dict
+
+        obj = objects.Organization.get_by_key(ctx, mock.sentinel.key)
+        ctx.store.get_one.assert_called_once_with(ctx, mock.sentinel.key)
+        self.assertEqual('funky', obj.name)

--- a/tox.ini
+++ b/tox.ini
@@ -6,16 +6,9 @@ deps = -r{toxinidir}/requirements.txt
        -r{toxinidir}/test-requirements.txt
 setenv = 
     VIRTUAL_ENV = {envdir}
-    PROCESSION_TEST = 1
 commands =
    python setup.py testr --slowest --testr-args='--concurrency=1 {posargs}'
-# Needed for cython
-sitepackages = True
 downloadcache = {toxworkdir}/_download
-
-[testenv:cover]
-setenv = VIRTUAL_ENV={envdir}
-commands = python setup.py testr --coverage --testr-args='--concurrency=1 {posargs}'
 
 [testenv:pep8]
 deps = -r{toxinidir}/test-requirements.txt


### PR DESCRIPTION
Corrected a problem where the from_dict() method was not properly
translating non-Capnp field names. Adds a few unit tests around base
object methods, and cleaned up the tox.ini file after noticing that the
testenv:cover environment was using site-packages for the six library.