### PR TITLE
More unit tests for the base object class

### DIFF
--- a/procession/objects.py
+++ b/procession/objects.py
@@ -304,11 +304,11 @@ class Object(object):
         :raises `procession.exc.NotFound` if no such object found in backend
                 storage.
         """
-        ctx = cls._find_ctx(ctx_or_req)
         if helpers.is_like_uuid(slug_or_key):
-            data = ctx.store.get_by_key(cls, slug_or_key,
-                                        with_relations=with_relations)
+            return cls.get_by_key(ctx_or_req, slug_or_key,
+                                  with_relations=with_relations)
         else:
+            ctx = cls._find_ctx(ctx_or_req)
             filters = {
                 'slug': slug_or_key
             }
@@ -316,8 +316,8 @@ class Object(object):
                                             with_relations=with_relations)
             data = ctx.store.get_one(cls, search_spec)
 
-        # TODO(jaypipes): Implement ACLs here.
-        return cls.from_dict(data, ctx=ctx)
+            # TODO(jaypipes): Implement ACLs here.
+            return cls.from_dict(data, ctx=ctx)
 
     @classmethod
     def get_one(cls, search_spec):

--- a/procession/rest/context.py
+++ b/procession/rest/context.py
@@ -17,7 +17,7 @@
 from procession import context
 from procession import store
 
-_ENV_IDENTIFIER = 'procession.ctx'
+ENV_IDENTIFIER = 'procession.ctx'
 
 
 def from_http_req(request):
@@ -30,7 +30,7 @@ def from_http_req(request):
     :param conf: `procession.config.Config` object reference from the
                  controller.
     """
-    return request.env[_ENV_IDENTIFIER]
+    return request.env[ENV_IDENTIFIER]
 
 
 def assure_context(req, resp, resource, params):
@@ -41,4 +41,4 @@ def assure_context(req, resp, resource, params):
     """
     ctx = context.Context()
     ctx.store = store.Store(resource.conf)
-    req.env[_ENV_IDENTIFIER] = ctx
+    req.env[ENV_IDENTIFIER] = ctx

--- a/procession/search.py
+++ b/procession/search.py
@@ -36,6 +36,7 @@ class SearchSpec(object):
                  filter_ors=None,
                  with_relations=None,
                  ):
+        self.ctx = context
         self.limit = limit
         self.marker = marker
         self.sort_by = sort_by or []
@@ -54,6 +55,7 @@ class SearchSpec(object):
         :raises `falcon.HTTPBadRequest` if sort by and sort dir lists are
                 not same length.
         """
+        ctx = context.from_http_req(req)
         limit = req.get_param_as_int('limit') or DEFAULT_LIMIT_RESULTS
         marker = req.get_param('marker')
         sort_by = req.get_param_as_list('sort_by') or list()
@@ -73,8 +75,7 @@ class SearchSpec(object):
         for name in ('limit', 'marker', 'sort_by', 'sort_dir', 'group_by'):
             if name in filters:
                 del filters[name]
-        ctx = context.from_http_req(req)
-        return cls(context=ctx,
+        return cls(ctx,
                    limit=limit,
                    marker=marker,
                    sort_by=sort_by,

--- a/procession/store.py
+++ b/procession/store.py
@@ -46,18 +46,6 @@ class Store(object):
         """
         self.driver.init()
 
-    def get_by_key(self, obj_type, key):
-        """
-        Returns a single Python dict that has a key matching the supplied
-        string.
-
-        :param obj_type: A `procession.objects.Object` class.
-        :param key: A string lookup key of the object.
-        :raises `procession.exc.NotFound` if no such object found in backend
-                storage.
-        """
-        return self.driver.get_by_key(obj_type, key)
-
     def get_one(self, obj_type, search_spec):
         """
         Returns a single Python dict that matches the supplied search spec.

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -93,7 +93,7 @@ class AuthenticatedRequestMock(RequestStub):
 
     def __init__(self, user_id=FAKE_UUID1):
         self.context = AuthenticatedContextMock(user_id)
-        self.env = {context._ENV_IDENTIFIER: self.context}
+        self.env = {context.ENV_IDENTIFIER: self.context}
         super(AuthenticatedRequestMock, self).__init__()
 
 
@@ -109,7 +109,7 @@ class AnonymousRequestMock(RequestStub):
 
     def __init__(self):
         self.context = AnonymousContextMock()
-        self.env = {context._ENV_IDENTIFIER: self.context}
+        self.env = {context.ENV_IDENTIFIER: self.context}
         super(AnonymousRequestMock, self).__init__()
 
 

--- a/tests/matchers.py
+++ b/tests/matchers.py
@@ -19,6 +19,7 @@
 import mock
 import pprint
 
+
 class SearchSpecMismatch(object):
 
     def __init__(self, attr, expected, actual):

--- a/tests/matchers.py
+++ b/tests/matchers.py
@@ -1,0 +1,69 @@
+# -*- encoding: utf-8 -*-
+#
+# Copyright 2015 Jay Pipes
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+"""Matchers used with the testtools.assertThat match framework"""
+
+import mock
+import pprint
+
+class SearchSpecMismatch(object):
+
+    def __init__(self, attr, expected, actual):
+        self.attr = attr
+        self.expected = expected
+        self.actual = actual
+
+    def describe(self):
+        msg = ("SearchSpec expected to match attribute {0} with value "
+               "{1} but found {2}")
+        msg = msg.format(self.attr, self.expected, self.actual)
+
+    def get_details(self):
+        return {}
+
+
+class SearchSpecMatches(object):
+
+    def __init__(self,
+                 limit=None,
+                 marker=None,
+                 sort_by=None,
+                 sort_dir=None,
+                 group_by=None,
+                 filters=None,
+                 filter_ors=None,
+                 with_relations=None,
+                 ):
+        self.limit = limit or mock.ANY
+        self.marker = marker or mock.ANY
+        self.sort_by = sort_by or mock.ANY
+        self.sort_dir = sort_dir or mock.ANY
+        self.group_by = group_by or mock.ANY
+        self.filters = filters or mock.ANY
+        self.filter_ors = filter_ors or mock.ANY
+        self.with_relations = with_relations or mock.ANY
+
+    def __str__(self):
+        return 'SearchSpecMatches(%s)' % pprint.pformat(self.__dict__)
+
+    def match(self, other):
+        for attr in ('limit', 'marker', 'sort_by', 'sort_dir', 'group_by',
+                     'filters', 'filter_ors', 'with_relations'):
+            this_attr = getattr(self, attr)
+            if this_attr != mock.ANY:
+                other_attr = getattr(other, attr)
+                if this_attr != other_attr:
+                    return SearchSpecMismatch(attr, this_attr, other_attr)

--- a/tests/objects/fixtures.py
+++ b/tests/objects/fixtures.py
@@ -19,15 +19,15 @@ import datetime
 from procession import objects
 
 
-_UUID1 = 'c52007d5-dbca-4897-a86a-51e800753dec'
-_UUID2 = '1c552546-73a6-445b-83e8-c07e1b5eaf10'
+UUID1 = 'c52007d5-dbca-4897-a86a-51e800753dec'
+UUID2 = '1c552546-73a6-445b-83e8-c07e1b5eaf10'
 _FINGERPRINT1 = '43:51:43:a1:b5:fc:8b:b7:0a:3a:a9:b1:0f:66:73:a8'
 _FINGERPRINT2 = '8a:37:66:f0:1b:9a:a3:a0:7b:b8:cf:5b:1a:34:15:34'
 _CREATED_ON = str(datetime.datetime(2013, 4, 27, 2, 45, 2))
 
 ORGANIZATIONS = [
     objects.Organization.from_values(
-        id=_UUID1,
+        id=UUID1,
         name='Jets',
         slug='Jets',
         parent_organization_id='',
@@ -35,7 +35,7 @@ ORGANIZATIONS = [
         created_on=_CREATED_ON
     ),
     objects.Organization.from_values(
-        id=_UUID2,
+        id=UUID2,
         name='Sharks',
         slug='sharks',
         parent_organization_id='',
@@ -46,14 +46,14 @@ ORGANIZATIONS = [
 
 USERS = [
     objects.User.from_values(
-        id=_UUID1,
+        id=UUID1,
         name='Albert Einstein',
         slug='albert-einstein',
         email='albert@emcsquared.com',
         created_on=_CREATED_ON,
     ),
     objects.User.from_values(
-        id=_UUID1,
+        id=UUID1,
         name='Charles Darwin',
         slug='charles-darwin',
         email='chuck@evolved.com',
@@ -63,13 +63,13 @@ USERS = [
 
 USER_PUBLIC_KEYS = [
     objects.UserPublicKey.from_values(
-        user_id=_UUID1,
+        user_id=UUID1,
         fingerprint=_FINGERPRINT1,
         public_key='emcsquared key',
         created_on=_CREATED_ON,
     ),
     objects.UserPublicKey.from_values(
-        user_id=_UUID2,
+        user_id=UUID2,
         fingerprint=_FINGERPRINT2,
         public_key='evolved key',
         created_on=_CREATED_ON,

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -107,10 +107,10 @@ class TestObjects(base.UnitTest):
         expected_filters = {
             'id': mock.sentinel.key
         }
-        search_spec_match = matchers.SearchSpecMatches(filters=expected_filters)
+        search_match = matchers.SearchSpecMatches(filters=expected_filters)
         call_args = ctx.store.get_one.call_args[0]
         self.assertEqual(objects.Organization, call_args[0])
-        self.assertThat(call_args[1], search_spec_match)
+        self.assertThat(call_args[1], search_match)
         self.assertEqual('My org', obj.name)
 
     def test_get_by_key_with_http_req(self):
@@ -127,10 +127,10 @@ class TestObjects(base.UnitTest):
         expected_filters = {
             'id': mock.sentinel.key
         }
-        search_spec_match = matchers.SearchSpecMatches(filters=expected_filters)
+        search_match = matchers.SearchSpecMatches(filters=expected_filters)
         call_args = self.ctx.store.get_one.call_args[0]
         self.assertEqual(objects.Organization, call_args[0])
-        self.assertThat(call_args[1], search_spec_match)
+        self.assertThat(call_args[1], search_match)
         self.assertEqual('My org', obj.name)
 
     def test_get_by_slug_or_key_with_key(self):
@@ -145,10 +145,10 @@ class TestObjects(base.UnitTest):
         expected_filters = {
             'id': fixtures.UUID1
         }
-        search_spec_match = matchers.SearchSpecMatches(filters=expected_filters)
+        search_match = matchers.SearchSpecMatches(filters=expected_filters)
         call_args = ctx.store.get_one.call_args[0]
         self.assertEqual(objects.Organization, call_args[0])
-        self.assertThat(call_args[1], search_spec_match)
+        self.assertThat(call_args[1], search_match)
         self.assertEqual('My org', obj.name)
 
     def test_get_by_slug_or_key_with_slug(self):
@@ -163,10 +163,10 @@ class TestObjects(base.UnitTest):
         expected_filters = {
             'slug': 'not-a-uuid'
         }
-        search_spec_match = matchers.SearchSpecMatches(filters=expected_filters)
+        search_match = matchers.SearchSpecMatches(filters=expected_filters)
         call_args = ctx.store.get_one.call_args[0]
         self.assertEqual(objects.Organization, call_args[0])
-        self.assertThat(call_args[1], search_spec_match)
+        self.assertThat(call_args[1], search_match)
         self.assertEqual('My org', obj.name)
 
     def test_get_one(self):
@@ -179,5 +179,6 @@ class TestObjects(base.UnitTest):
 
         search_spec = search.SearchSpec(ctx, filters=dict(name='My org'))
         obj = objects.Organization.get_one(search_spec)
-        ctx.store.get_one.assert_called_once_with(objects.Organization, search_spec)
+        ctx.store.get_one.assert_called_once_with(objects.Organization,
+                                                  search_spec)
         self.assertEqual('My org', obj.name)


### PR DESCRIPTION
Adds a number of unit tests for the base object class. In the process of
writing the unit tests, I discovered that
procession.objects.Object.get_by_key() was erroneously calling a
non-existent store driver method get_by_key(), and this was fixed to
properly call the store driver method get_one(), supplying a built
SearchSpec object.