### PR TITLE
 unit-tests: First round of tests for SQL driver

### DIFF
--- a/procession/exc.py
+++ b/procession/exc.py
@@ -1,6 +1,6 @@
 # -*- encoding: utf-8 -*-
 #
-# Copyright 2013-2014 Jay Pipes
+# Copyright 2013-2015 Jay Pipes
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License. You may obtain
@@ -36,4 +36,8 @@ class NoContext(RuntimeError):
 
 
 class InvalidRelation(RuntimeError):
+    pass
+
+
+class UnknownObjectType(RuntimeError):
     pass

--- a/procession/storage/base.py
+++ b/procession/storage/base.py
@@ -1,0 +1,139 @@
+# -*- encoding: utf-8 -*-
+#
+# Copyright 2015 Jay Pipes
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+import abc
+
+class Driver(metaclass=abc.ABCMeta):
+
+    def init(self):
+        """
+        Do any startup/once-only actions.
+        """
+        pass
+
+    @abc.abstractmethod
+    def get_one(self, obj_type, search_spec):
+        """
+        Returns a single Python dict that matches the supplied search spec.
+
+        :param obj_type: A `procession.objects.Object` class.
+        :param search_spec: A `procession.search.SearchSpec` object.
+        :raises `procession.exc.NotFound` if no such object found in backend
+                storage.
+        """
+        raise NotImplementedError('get_one')
+
+    @abc.abstractmethod
+    def get_many(self, obj_type, search_spec):
+        """
+        Returns a list of Python dicts of records that match the supplied
+        search spec.
+
+        :param obj_type: A `procession.objects.Object` class.
+        :param search_spec: A `procession.search.SearchSpec` object.
+        """
+        raise NotImplementedError('get_many')
+
+    @abc.abstractmethod
+    def exists(self, obj_type, key):
+        """
+        Returns True if an object of the supplied type and key exists
+        in backend storage.
+
+        :param obj_type: A `procession.objects.Object` class.
+        :param key: list of strings or string key for the object.
+        """
+        raise NotImplementedError('exists')
+
+    @abc.abstractmethod
+    def delete(self, obj_type, keys):
+        """
+        Deletes all objects of the supplied type with matching supplied
+        keys from backend storage.
+
+        :param obj_type: A `procession.objects.Object` class.
+        :param key: list of strings or string key for the object.
+        """
+        raise NotImplementedError('delete')
+
+    @abc.abstractmethod
+    def save(self, obj_type, key, **values):
+        """
+        Writes the supplied field values for an object type to backend storage.
+
+        :param obj_type: A `procession.objects.Object` class.
+        :param key: A string key for the record.
+        :param **values: Dictionary of field values to set on the object.
+        :raises `procession.exc.Duplicate` if an object with the same
+                identifier(s) already exists.
+        """
+        raise NotImplementedError('save')
+
+    @abc.abstractmethod
+    def add_relation(self, parent_obj_type, child_obj_type,
+                     parent_key, child_key):
+        """
+        Adds a many-to-many relation between a parent and a child object.
+
+        :param parent_obj_type: A `procession.objects.Object` class for the
+                                parent side of the relation.
+        :param child_obj_type: A `procession.objects.Object` class for the
+                               child side of the relation.
+        :param parent_key: A string key for the parent record.
+        :param child_key: A string key for the child record.
+        :raises `procession.exc.NotFound` if either parent or child key
+                does not exist in backend storage.
+        """
+        raise NotImplementedError('add_relation')
+
+    @abc.abstractmethod
+    def remove_relation(self, parent_obj_type, child_obj_type,
+                        parent_key, child_key):
+        """
+        Removes a many-to-many relation between a parent and a child object.
+
+        :param parent_obj_type: A `procession.objects.Object` class for the
+                                parent side of the relation.
+        :param child_obj_type: A `procession.objects.Object` class for the
+                               child side of the relation.
+        :param parent_key: A string key for the parent record.
+        :param child_key: A string key for the child record.
+        :raises `procession.exc.NotFound` if either parent or child key
+                does not exist in backend storage.
+        """
+        raise NotImplementedError('remove_relation')
+
+    @abc.abstractmethod
+    def get_relations(self, parent_obj_type, child_obj_type,
+                      parent_search_spec, child_search_spec=None):
+        """
+        Returns a list of Python dicts of records of the child type
+        that match the supplied search spec for the parent and
+        child relation types. Used for many-to-many relationship traversal,
+        for instance with user -> group membership.
+
+        :param parent_obj_type: A `procession.objects.Object` class for the
+                                parent side of the relation.
+        :param child_obj_type: A `procession.objects.Object` class for the
+                               child side of the relation.
+        :param parent_search_spec: A `procession.search.SearchSpec` object with
+                                   conditions for the parent side of the
+                                   relation.
+        :param child_search_spec: A `procession.search.SearchSpec` object with
+                                  conditions for the child side of the
+                                  relation.
+        """
+        raise NotImplementedError('get_relations')

--- a/procession/storage/sql/driver.py
+++ b/procession/storage/sql/driver.py
@@ -41,7 +41,10 @@ _OBJECT_RELATIONS_MAP = {
 
 def _get_db_model_from_obj_class(obj_class):
     obj_type = obj_class._SINGULAR_NAME
-    return _OBJECT_TO_DB_MODEL_MAP[obj_type]
+    try:
+        return _OBJECT_TO_DB_MODEL_MAP[obj_type]
+    except KeyError:
+        raise exc.UnknownObjectType(obj_class)
 
 
 class Driver(object):

--- a/procession/storage/sql/driver.py
+++ b/procession/storage/sql/driver.py
@@ -149,7 +149,7 @@ class Driver(object):
         model = _get_db_model_from_obj_class(obj_type)
         return api.exists(sess, model, key)
 
-    def remove(self, obj_type, keys):
+    def delete(self, obj_type, keys):
         """
         Deletes all objects of the supplied type with matching supplied
         keys from backend storage.
@@ -161,11 +161,13 @@ class Driver(object):
         model = _get_db_model_from_obj_class(obj_type)
         return api.remove(sess, model, keys)
 
-    def save(self, obj):
+    def save(self, obj_type, key, **values):
         """
-        Writes the supplied object to backend storage.
+        Writes the supplied field values for an object type to backend storage.
 
-        :param obj: A `procession.objects.Object` object.
+        :param obj_type: A `procession.objects.Object` class.
+        :param key: A string key for the record.
+        :param **values: Dictionary of field values to set on the object.
         :raises `procession.exc.Duplicate` if an object with the same
                 identifier(s) already exists.
         """

--- a/procession/storage/sql/models.py
+++ b/procession/storage/sql/models.py
@@ -81,7 +81,7 @@ class CoerceUTF8(types.TypeDecorator):
     impl = types.Unicode
 
     def process_bind_param(self, value, dialect):
-        if isinstance(value, str):
+        if isinstance(value, bytes):
             value = value.decode('utf-8')
         return value
 

--- a/procession/store.py
+++ b/procession/store.py
@@ -133,9 +133,9 @@ class Store(object):
         :param obj_type: A `procession.objects.Object` class.
         :param key: list of strings or string key for the object.
         """
-        return self.driver.exists(obj_type)
+        return self.driver.exists(obj_type, key)
 
-    def remove(self, obj_type, keys):
+    def delete(self, obj_type, keys):
         """
         Deletes all objects of the supplied type with matching supplied
         keys from backend storage.
@@ -143,14 +143,16 @@ class Store(object):
         :param obj_type: A `procession.objects.Object` class.
         :param key: list of strings or string key for the object.
         """
-        return self.driver.remove(obj_type, keys)
+        return self.driver.delete(obj_type, keys)
 
-    def save(self, obj_type, **values):
+    def save(self, obj_type, key, **values):
         """
         Writes the supplied field values for an object type to backend storage.
 
         :param obj_type: A `procession.objects.Object` class.
+        :param key: A string key for the record.
+        :param **values: Dictionary of field values to set on the object.
         :raises `procession.exc.Duplicate` if an object with the same
                 identifier(s) already exists.
         """
-        self.driver.save(obj_type, **values)
+        self.driver.save(obj_type, key, **values)

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -14,6 +14,8 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+import datetime
+
 import mock
 
 from procession.rest import context
@@ -29,6 +31,13 @@ def get_search_spec(**kwargs):
 
 
 NO_EXIST_UUID = '99999999-9999-9999-9999-999999999999'
+
+UUID1 = 'c52007d5-dbca-4897-a86a-51e800753dec'
+UUID2 = '1c552546-73a6-445b-83e8-c07e1b5eaf10'
+FINGERPRINT1 = '43:51:43:a1:b5:fc:8b:b7:0a:3a:a9:b1:0f:66:73:a8'
+FINGERPRINT2 = '8a:37:66:f0:1b:9a:a3:a0:7b:b8:cf:5b:1a:34:15:34'
+CREATED_ON = datetime.datetime(2013, 4, 27, 2, 45, 2)
+
 FAKE_UUID1 = 'c52007d5-dbca-4897-a86a-51e800753dec'
 FAKE_UUID2 = '1c552546-73a6-445b-83e8-c07e1b5eaf10'
 FAKE_FINGERPRINT1 = '43:51:43:a1:b5:fc:8b:b7:0a:3a:a9:b1:0f:66:73:a8'

--- a/tests/objects/fixtures.py
+++ b/tests/objects/fixtures.py
@@ -18,60 +18,55 @@ import datetime
 
 from procession import objects
 
-
-UUID1 = 'c52007d5-dbca-4897-a86a-51e800753dec'
-UUID2 = '1c552546-73a6-445b-83e8-c07e1b5eaf10'
-_FINGERPRINT1 = '43:51:43:a1:b5:fc:8b:b7:0a:3a:a9:b1:0f:66:73:a8'
-_FINGERPRINT2 = '8a:37:66:f0:1b:9a:a3:a0:7b:b8:cf:5b:1a:34:15:34'
-_CREATED_ON = str(datetime.datetime(2013, 4, 27, 2, 45, 2))
+from tests import fixtures
 
 ORGANIZATIONS = [
     objects.Organization.from_values(
-        id=UUID1,
+        id=fixtures.UUID1,
         name='Jets',
         slug='Jets',
         parent_organization_id='',
         root_organization_id='',
-        created_on=_CREATED_ON
+        created_on=fixtures.CREATED_ON
     ),
     objects.Organization.from_values(
-        id=UUID2,
+        id=fixtures.UUID2,
         name='Sharks',
         slug='sharks',
         parent_organization_id='',
         root_organization_id='',
-        created_on=_CREATED_ON
+        created_on=fixtures.CREATED_ON
     ),
 ]
 
 USERS = [
     objects.User.from_values(
-        id=UUID1,
+        id=fixtures.UUID1,
         name='Albert Einstein',
         slug='albert-einstein',
         email='albert@emcsquared.com',
-        created_on=_CREATED_ON,
+        created_on=fixtures.CREATED_ON,
     ),
     objects.User.from_values(
-        id=UUID1,
+        id=fixtures.UUID1,
         name='Charles Darwin',
         slug='charles-darwin',
         email='chuck@evolved.com',
-        created_on=_CREATED_ON,
+        created_on=fixtures.CREATED_ON,
     ),
 ]
 
 USER_PUBLIC_KEYS = [
     objects.UserPublicKey.from_values(
-        user_id=UUID1,
-        fingerprint=_FINGERPRINT1,
+        user_id=fixtures.UUID1,
+        fingerprint=fixtures.FINGERPRINT1,
         public_key='emcsquared key',
-        created_on=_CREATED_ON,
+        created_on=fixtures.CREATED_ON,
     ),
     objects.UserPublicKey.from_values(
-        user_id=UUID2,
-        fingerprint=_FINGERPRINT2,
+        user_id=fixtures.UUID2,
+        fingerprint=fixtures.FINGERPRINT2,
         public_key='evolved key',
-        created_on=_CREATED_ON,
+        created_on=fixtures.CREATED_ON,
     ),
 ]

--- a/tests/rest/resources/base.py
+++ b/tests/rest/resources/base.py
@@ -18,7 +18,7 @@ import pprint
 
 from testtools import content as ttcontent
 
-from tests import fakes
+from tests import fixtures
 from tests import base
 
 
@@ -31,7 +31,7 @@ class ResourceTestCase(base.UnitTest):
 
     def setUp(self):
         self.mocks = []
-        self.resp = fakes.ResponseMock()
+        self.resp = fixtures.ResponseMock()
         self.patch('procession.rest.helpers.serialize', lambda x, y: y)
         super(ResourceTestCase, self).setUp()
 
@@ -44,7 +44,7 @@ class ResourceTestCase(base.UnitTest):
         Calls the supplied resource method, passing in a non-authenticated
         request object.
         """
-        self.req = fakes.AnonymousRequestMock()
+        self.req = fixtures.AnonymousRequestMock()
         self.ctx = self.req.context
         resource_method(self.req, self.resp, *args, **kwargs)
         self.add_body_detail()
@@ -54,7 +54,7 @@ class ResourceTestCase(base.UnitTest):
         Calls the supplied resource method, passing in an authenticated
         request object.
         """
-        self.req = fakes.AuthenticatedRequestMock()
+        self.req = fixtures.AuthenticatedRequestMock()
         self.ctx = self.req.context
         resource_method(self.req, self.resp, *args, **kwargs)
         self.add_body_detail()

--- a/tests/rest/test_auth.py
+++ b/tests/rest/test_auth.py
@@ -21,7 +21,7 @@ import testtools
 from procession import config
 from procession.rest import auth
 
-from tests import fakes
+from tests import fixtures
 from tests import base
 
 
@@ -42,7 +42,7 @@ class TestApiAuth(base.UnitTest):
                 resp.status = falcon.HTTP_200
 
         req = mock.MagicMock()
-        resp = fakes.ResponseMock()
+        resp = fixtures.ResponseMock()
         resource = MyResource()
         with mock.patch('procession.rest.auth.authenticate',
                         return_value=False):
@@ -75,8 +75,8 @@ class TestApiAuth(base.UnitTest):
             def get_header(self, header):
                 return self.headers.get(header.lower())
 
-        anon_ctx = fakes.AnonymousContextMock()
-        auth_ctx = fakes.AuthenticatedContextMock()
+        anon_ctx = fixtures.AnonymousContextMock()
+        auth_ctx = fixtures.AuthenticatedContextMock()
 
         self.assertFalse(auth.authenticate(anon_ctx, FakeRequest()))
         self.assertTrue(auth.authenticate(auth_ctx, FakeRequest()))

--- a/tests/storage/sql/fixtures.py
+++ b/tests/storage/sql/fixtures.py
@@ -1,0 +1,40 @@
+# -*- encoding: utf-8 -*-
+#
+# Copyright 2015 Jay Pipes
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+import fixtures
+import sqlalchemy
+
+from procession.storage.sql import models
+
+
+class OrganizationInDb(fixtures.Fixture):
+    def __init__(self, engine, metadata, **values):
+        self.values = values
+        self.engine = engine
+        self.metadata = metadata
+        self.orgs = metadata.tables['organizations']
+
+    def remove_from_db(self):
+        id_col = self.orgs.c.id
+        delete = self.orgs.delete().where(id_col == self.values['id'])
+        conn = self.engine.connect()
+        conn.execute(delete)
+
+    def _setUp(self):
+        ins = self.orgs.insert().values(**self.values)
+        conn = self.engine.connect()
+        conn.execute(ins)
+        self.addCleanup(self.remove_from_db)

--- a/tests/storage/sql/test_driver.py
+++ b/tests/storage/sql/test_driver.py
@@ -1,0 +1,84 @@
+# -*- encoding: utf-8 -*-
+#
+# Copyright 2015 Jay Pipes
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+import testtools
+
+from procession import config
+from procession import context
+from procession import exc
+from procession import objects
+from procession import search
+from procession.storage.sql import models
+from procession.storage.sql import driver
+
+from tests import base
+from tests import fixtures
+from tests.storage.sql import fixtures as sql_fixtures
+
+
+class TestSqlDriver(base.UnitTest):
+    def setUp(self):
+        super(TestSqlDriver, self).setUp()
+        self.ctx = context.Context()
+        store_conf = {
+            'driver': 'sql',
+            'connection': 'sqlite:///:memory:',
+        }
+        self.conf = config.Config(store=store_conf)
+        self.driver = driver.Driver(self.conf)
+        models.ModelBase.metadata.create_all(self.driver.engine)
+
+    def test__get_session(self):
+        self.assertIsNone(self.driver.session)
+        sess = self.driver._get_session()
+        self.assertIsNotNone(sess)
+        self.assertIsNotNone(self.driver.session)
+
+    def test_get_one_unknown_obj_type(self):
+        class UnknownObject(objects.Object):
+            pass
+
+        with testtools.ExpectedException(exc.UnknownObjectType):
+            self.driver.get_one(UnknownObject, 'fake-key')
+
+    def test_get_one_not_found(self):
+        filters = {
+            'id': fixtures.NO_EXIST_UUID,
+        }
+        search_spec = search.SearchSpec(self.ctx, filters=filters)
+        with testtools.ExpectedException(exc.NotFound):
+            self.driver.get_one(objects.Organization, search_spec)
+
+    def test_get_one(self):
+        org = sql_fixtures.OrganizationInDb(self.driver.engine,
+                                            models.ModelBase.metadata,
+                                            id=fixtures.UUID1,
+                                            name='fake-name',
+                                            slug='fake-name',
+                                            created_on=fixtures.CREATED_ON,
+                                            root_organization_id=fixtures.UUID1,
+                                            parent_organization_id=None,
+                                            left_sequence=1,
+                                            right_sequence=2)
+        self.useFixture(org)
+        filters = {
+            'id': fixtures.UUID1,
+        }
+        search_spec = search.SearchSpec(self.ctx, filters=filters)
+        r = self.driver.get_one(objects.Organization, search_spec)
+        self.assertEqual(fixtures.UUID1, str(r['id']))
+        self.assertEqual('fake-name', r['name'])
+        self.assertEqual(fixtures.CREATED_ON, r['created_on'])

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -21,7 +21,7 @@ import testtools
 
 from procession import helpers
 
-from tests import fakes
+from tests import fixtures
 from tests import base
 
 
@@ -40,8 +40,8 @@ class TestIsLikeUuid(base.UnitTest):
             self.assertFalse(helpers.is_like_uuid(subject))
 
         good_subjects = [
-            fakes.FAKE_UUID1,
-            fakes.FAKE_UUID2
+            fixtures.UUID1,
+            fixtures.UUID2
         ]
         for subject in good_subjects:
             self.assertTrue(helpers.is_like_uuid(subject))

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -30,8 +30,8 @@ from procession.rest import context as rcontext
 from procession import search
 
 from tests import base
+from tests import fixtures
 from tests import matchers
-from tests.objects import fixtures
 
 
 class TestObjects(base.UnitTest):

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -1,0 +1,142 @@
+# -*- encoding: utf-8 -*-
+#
+# Copyright 2015 Jay Pipes
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+import collections
+
+import fixtures
+import mock
+import testtools
+
+from procession import config
+from procession import store
+from procession.storage import base as base_storage
+
+from tests import base
+
+
+class FakeDriver(base_storage.Driver):
+    def __init__(self, conf):
+        self.conf = conf
+        self.deleted = False
+        self.saved = False
+        self.relations = set()
+    def get_one(self, obj_type, search_spec):
+        return mock.sentinel.get_one
+    def get_many(self, obj_type, search_spec):
+        return mock.sentinel.get_many
+    def exists(self, obj_type, key):
+        return mock.sentinel.exists
+    def delete(self, obj_type, keys):
+        self.deleted = True
+    def save(self, obj_type, key, **values):
+        self.saved = True
+    def add_relation(self, parent_obj_type, child_obj_type,
+                     parent_key, child_key):
+        self.relations.add((parent_obj_type,
+                            child_obj_type,
+                            parent_key,
+                            child_key))
+    def remove_relation(self, parent_obj_type, child_obj_type,
+                        parent_key, child_key):
+        self.relations.remove((parent_obj_type,
+                               child_obj_type,
+                               parent_key,
+                               child_key))
+    def get_relations(self, parent_obj_type, child_obj_type,
+                      parent_search_spec, child_search_spec=None):
+        return mock.sentinel.get_relations
+
+
+class AddFakeStoreDriver(fixtures.Fixture):
+    def _setUp(self):
+        self.orig_drivers = store._VALID_STORE_DRIVERS
+        self.orig_driver_cls_map = store._STORE_DRIVER_CLS_MAP
+        store._VALID_STORE_DRIVERS = ('fake', )
+        store._STORE_DRIVER_CLS_MAP = {'fake': FakeDriver}
+
+        self.addCleanup(setattr, store, '_VALID_STORE_DRIVERS',
+                        self.orig_drivers)
+        self.addCleanup(setattr, store, '_STORE_DRIVER_CLS_MAP',
+                        self.orig_driver_cls_map)
+
+
+class TestBadStore(base.UnitTest):
+    def test_bad_store_driver(self):
+        store_conf = {
+            'driver': 'unknown'
+        }
+        conf = config.Config(store=store_conf)
+        with testtools.ExpectedException(RuntimeError):
+            store.Store(conf)
+
+
+class TestStoreInterface(base.UnitTest):
+    def setUp(self):
+        super(TestStoreInterface, self).setUp()
+        self.useFixture(AddFakeStoreDriver())
+        store_conf = {
+            'driver': 'fake'
+        }
+        conf = config.Config(store=store_conf)
+        self.store_obj = store.Store(conf)
+
+    def test__init__(self):
+        self.assertEqual('fake', self.store_obj.driver.conf.store.driver)
+
+    def test_get_one(self):
+        r = self.store_obj.get_one(mock.sentinel.obj_type, mock.sentinel.key)
+        self.assertEqual(mock.sentinel.get_one, r)
+
+    def test_get_many(self):
+        r = self.store_obj.get_many(mock.sentinel.obj_type, mock.sentinel.key)
+        self.assertEqual(mock.sentinel.get_many, r)
+
+    def test_exists(self):
+        r = self.store_obj.exists(mock.sentinel.obj_type, mock.sentinel.key)
+        self.assertEqual(mock.sentinel.exists, r)
+
+    def test_delete(self):
+        self.assertFalse(self.store_obj.driver.deleted)
+        self.store_obj.delete(mock.sentinel.obj_type, mock.sentinel.key)
+        self.assertTrue(self.store_obj.driver.deleted)
+
+    def test_save(self):
+        self.assertFalse(self.store_obj.driver.saved)
+        self.store_obj.save(mock.sentinel.obj_type, mock.sentinel.key)
+        self.assertTrue(self.store_obj.driver.saved)
+
+    def test_get_relations(self):
+        r = self.store_obj.get_relations(mock.sentinel.parent_obj_type,
+                                         mock.sentinel.child_obj_type,
+                                         mock.sentinel.parent_search)
+        self.assertEqual(mock.sentinel.get_relations, r)
+
+    def test_modify_relations(self):
+        rel_key = (mock.sentinel.parent_obj_type,
+                   mock.sentinel.child_obj_type,
+                   mock.sentinel.parent_key,
+                   mock.sentinel.child_key)
+        self.assertEqual(set(), self.store_obj.driver.relations)
+        self.store_obj.add_relation(mock.sentinel.parent_obj_type,
+                                    mock.sentinel.child_obj_type,
+                                    mock.sentinel.parent_key,
+                                    mock.sentinel.child_key)
+        self.assertEqual(set([rel_key]), self.store_obj.driver.relations)
+        self.store_obj.remove_relation(mock.sentinel.parent_obj_type,
+                                       mock.sentinel.child_obj_type,
+                                       mock.sentinel.parent_key,
+                                       mock.sentinel.child_key)
+        self.assertEqual(set(), self.store_obj.driver.relations)


### PR DESCRIPTION
Adds the first round of unit tests for the SQL store driver. In doing
so, makes a number of changes to the fixtures used in unit tests:

- renames tests/fakes.py to tests/fixtures.py
- Adds fixture class for ensuring an organization record in db