### PR TITLE
Adds save() method implementation in store driver

### DIFF
--- a/procession/storage/base.py
+++ b/procession/storage/base.py
@@ -63,7 +63,7 @@ class Driver(object):
         raise NotImplementedError('exists')  # pragma: no cover
 
     @abc.abstractmethod
-    def delete(self, obj_type, keys):
+    def delete(self, obj_type, key):
         """
         Deletes all objects of the supplied type with matching supplied
         keys from backend storage.
@@ -74,15 +74,15 @@ class Driver(object):
         raise NotImplementedError('delete')  # pragma: no cover
 
     @abc.abstractmethod
-    def save(self, obj_type, key, **values):
+    def save(self, obj):
         """
-        Writes the supplied field values for an object type to backend storage.
+        Writes the supplied object to backend storage. A new object of the same
+        type is returned, possibly with some new fields set -- e.g.
+        autoincrementing sequences or auto-generated timestamp fields.
 
-        :param obj_type: A `procession.objects.Object` class.
-        :param key: A string key for the record.
-        :param **values: Dictionary of field values to set on the object.
-        :raises `procession.exc.Duplicate` if an object with the same
-                identifier(s) already exists.
+        :param obj: A `procession.objects.Object` instance.
+        :returns A new `procession.objects.Object` instance of the same type as
+                 the supplied object.
         """
         raise NotImplementedError('save')  # pragma: no cover
 

--- a/procession/storage/sql/api.py
+++ b/procession/storage/sql/api.py
@@ -685,21 +685,19 @@ def group_users_get(ctx, group_id, **kwargs):
     return conn.execute(sel).fetchall()
 
 
-def user_create(ctx, attrs, **kwargs):
+def user_create(sess, attrs):
     """
-    Creates a user in the database. The session (either supplied or
-    auto-created) is always committed upon successful creation.
+    Creates a user in the database. The session is always committed upon
+    successful creation.
 
-    :param ctx: `procession.context.Context` object
+    :param sess: `sqlalchemy.Session` object
     :param attrs: dict with information about the user to create
 
-    :raises `procession.exc.Duplicate` if email already found
+    :raises `procession.exc.Duplicate` if email or ID already found
     :raises `ValueError` if validation of inputs fails
     :raises `TypeError` if unknown attribute is supplied
     :returns `procession.db.models.User` object that was created
     """
-    sess = ctx.store.get_session()
-
     u = models.User(**attrs)
     u.validate(attrs)
     u.set_slug()

--- a/procession/store.py
+++ b/procession/store.py
@@ -145,14 +145,14 @@ class Store(object):
         """
         return self.driver.delete(obj_type, key)
 
-    def save(self, obj_type, key, **values):
+    def save(self, obj):
         """
-        Writes the supplied field values for an object type to backend storage.
+        Writes the supplied object to backend storage. A new object of the same
+        type is returned, possibly with some new fields set -- e.g.
+        autoincrementing sequences or auto-generated timestamp fields.
 
-        :param obj_type: A `procession.objects.Object` class.
-        :param key: A string key for the record.
-        :param **values: Dictionary of field values to set on the object.
-        :raises `procession.exc.Duplicate` if an object with the same
-                identifier(s) already exists.
+        :param obj: A `procession.objects.Object` instance.
+        :returns A new `procession.objects.Object` instance of the same type as
+                 the supplied object.
         """
-        self.driver.save(obj_type, key, **values)
+        self.driver.save(obj)

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -44,7 +44,7 @@ class FakeDriver(base_storage.Driver):
     def delete(self, obj_type, keys):
         self.deleted = True
 
-    def save(self, obj_type, key, **values):
+    def save(self, obj):
         self.saved = True
 
     def add_relation(self, parent_obj_type, child_obj_type,
@@ -121,7 +121,7 @@ class TestStoreInterface(base.UnitTest):
 
     def test_save(self):
         self.assertFalse(self.store_obj.driver.saved)
-        self.store_obj.save(mock.sentinel.obj_type, mock.sentinel.key)
+        self.store_obj.save(mock.sentinel.obj)
         self.assertTrue(self.store_obj.driver.saved)
 
     def test_get_relations(self):


### PR DESCRIPTION
Adds the ability to call procession.store.Store.save(), passing in a
single procession.objects.Object instance. The SQL store driver is
updated with a method that translates the object into a set of DB API
parameters to a DB API method to create or update a record in the DB.
Additional methods and parameters were added to the base
procession.objects.Object class to deal with determining if an object
has ever been saved to backing storage (is_new()) and to grab the set of
field names for any fields that have had their values changed.