### PR TITLE
Add field value translators

### DIFF
--- a/procession/translators.py
+++ b/procession/translators.py
@@ -1,0 +1,52 @@
+# -*- encoding: utf-8 -*-
+#
+# Copyright 2015 Jay Pipes
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+import datetime
+
+import iso8601
+import six
+
+
+def parse_isotime(timestr):
+    """
+    Parse time from ISO 8601 format.
+
+    :note This code verbatim from `oslo_utils.timeutils` module.
+          Apache 2 licensed.
+    """
+    try:
+        return iso8601.parse_date(timestr)
+    except iso8601.ParseError as e:
+        raise ValueError(six.text_type(e))
+    except TypeError as e:
+        raise ValueError(six.text_type(e))
+
+
+def coerce_datetime(subject):
+    if isinstance(subject, datetime.datetime):
+        return subject
+    if isinstance(subject, six.string_types):
+        return datetime.datetime.utcfromtimestamp(subject).isoformat()
+    raise ValueError(six.text_type(subject))
+
+
+def coerce_iso8601_string(subject):
+    if isinstance(subject, datetime.datetime):
+        if subject.tzinfo is None:
+            subject = subject.replace(tzinfo=datetime.timezone.utc)
+        return subject.isoformat()
+    return parse_isotime(subject).isoformat()
+coerce_iso8601_string.reverser = coerce_datetime

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@
 pbr>=1.0.0
 
 falcon
+iso8601>=0.1.9
 jsonschema
 pyyaml
 python-slugify

--- a/tests/test_translators.py
+++ b/tests/test_translators.py
@@ -1,0 +1,51 @@
+# -*- encoding: utf-8 -*-
+#
+# Copyright 2015 Jay Pipes
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+import datetime
+
+import six
+import testtools
+
+from procession import translators
+
+from tests import base
+
+
+class TestTranslators(base.UnitTest):
+    def test_coerce_iso8601_string_success(self):
+        subjects = [
+            datetime.datetime(2015, 1, 23, 10, 36, 22,
+                              tzinfo=datetime.timezone.utc),
+            datetime.datetime(2015, 1, 23, 10, 36, 22),
+            '2015-01-23T10:36:22Z',
+            '2015-01-23T10:36:22',
+            '2015-01-23T10:36:22+00:00',
+            '2015-01-23T10:36:22-00:00',
+        ]
+        expected = six.text_type('2015-01-23T10:36:22+00:00')
+        for subject in subjects:
+            res = translators.coerce_iso8601_string(subject)
+            msg = "Failed to coerce %r to %r. Got %r instead."
+            msg = msg % (subject, expected, res)
+            self.assertEqual(expected, res, msg)
+
+    def test_coerce_iso8601_string_failure(self):
+        subjects = [
+            '123'
+        ]
+        for subject in subjects:
+            with testtools.ExpectedException(ValueError):
+                translators.coerce_iso8601_string(subject)


### PR DESCRIPTION
Adds some coercion functions to a new procession.translators module.
These functions will be replacing the custom timestamp and nullstring
translations in the base object class.