### PR TITLE
Field value translators added to objects

### DIFF
--- a/tests/storage/sql/test_driver.py
+++ b/tests/storage/sql/test_driver.py
@@ -179,9 +179,9 @@ class TestSqlDriver(base.UnitTest):
             'id': str(mocks.UUID1),
             'name': 'org name',
             'slug': 'org-name',
-            'parent_organization_id': '',
+            'parent_organization_id': None,
             'root_organization_id': str(mocks.UUID1),
-            'created_on': str(mocks.CREATED_ON),
+            'created_on': mocks.CREATED_ON,
             'left_sequence': 1,
             'right_sequence': 2,
         }
@@ -201,8 +201,8 @@ class TestSqlDriver(base.UnitTest):
         self.assertIsInstance(res, objects.Organization)
         self.assertFalse(res.is_new)
         self.assertEqual(mocks.UUID1, res.id.decode('utf8'))
-        self.assertEqual(str(mocks.CREATED_ON), res.created_on)
-        self.assertEqual('', res.parent_organization_id.decode('utf8'))
+        self.assertEqual(mocks.CREATED_ON, res.created_on)
+        self.assertIsNone(res.parent_organization_id)
         self.assertEqual(mocks.UUID1, res.root_organization_id.decode('utf8'))
 
     @mock.patch('procession.storage.sql.api.user_update')
@@ -214,7 +214,7 @@ class TestSqlDriver(base.UnitTest):
             'id': str(mocks.UUID1),
             'name': 'new user name',
             'slug': 'new-user-name',
-            'created_on': str(mocks.CREATED_ON),
+            'created_on': mocks.CREATED_ON,
         }
         api_mock.return_value = model_mock
         values = {
@@ -232,5 +232,5 @@ class TestSqlDriver(base.UnitTest):
         self.assertIsInstance(res, objects.User)
         self.assertFalse(res.is_new)
         self.assertEqual(mocks.UUID1, res.id.decode('utf8'))
-        self.assertEqual(str(mocks.CREATED_ON), res.created_on)
+        self.assertEqual(mocks.CREATED_ON, res.created_on)
         self.assertEqual('new user name', res.name)

--- a/tests/test_translators.py
+++ b/tests/test_translators.py
@@ -28,7 +28,7 @@ class TestTranslators(base.UnitTest):
     def test_coerce_iso8601_string_success(self):
         subjects = [
             datetime.datetime(2015, 1, 23, 10, 36, 22,
-                              tzinfo=datetime.timezone.utc),
+                              tzinfo=translators._UTC),
             datetime.datetime(2015, 1, 23, 10, 36, 22),
             '2015-01-23T10:36:22Z',
             '2015-01-23T10:36:22',


### PR DESCRIPTION
* Adds generic field value translators to the base Object class,
  replacing the custom nullstring and timestamp converters.
* Object getattr, setattr, from_dict and to_dict now do inline
  conversion of the input and output values of fields.
* Corrects Python 2.7 handling of the UTC timezone object which doesn't
  exist in the Python 2 datetime module.