### PR TITLE
Remove get_relations() store and driver method

### DIFF
--- a/procession/objects.py
+++ b/procession/objects.py
@@ -525,11 +525,10 @@ class Group(Object):
     _CAPNP_OBJECT = group_capnp.Group
 
     def get_users(self, search_spec=None):
-        store = self.ctx.store
         if search_spec is None:
             search_spec = search.SearchSpec(self.ctx)
         search_spec.filter_by(group_id=self.id)
-        return store.get_relations(Group, User, search_spec)
+        return User.get_many(search_spec)
 
     def add_user(self, user_id):
         self.add_relation(User, user_id)
@@ -552,15 +551,14 @@ class User(Object):
     def get_public_keys(self, search_spec=None):
         if search_spec is None:
             search_spec = search.SearchSpec(ctx=self.ctx)
-            search_spec.filter_by(userId=self.id)
+        search_spec.filter_by(user_id=self.id)
         return UserPublicKey.get_many(search_spec)
 
     def get_groups(self, search_spec=None):
-        store = self.ctx.store
         if search_spec is None:
             search_spec = search.SearchSpec(self.ctx)
         search_spec.filter_by(user_id=self.id)
-        return store.get_relations(User, Group, search_spec)
+        return Group.get_many(search_spec)
 
     def add_group(self, group_id):
         self.add_relation(Group, group_id)
@@ -596,11 +594,10 @@ class Domain(Object):
     _CAPNP_OBJECT = domain_capnp.Domain
 
     def get_repos(self, search_spec=None):
-        store = self.ctx.store
         if search_spec is None:
             search_spec = search.SearchSpec(ctx=self.ctx)
-            search_spec.filter_by(domainId=self.id)
-        return store.get_relations(Domain, Repository, search_spec)
+        search_spec.filter_by(domain_id=self.id)
+        return Repository.get_many(search_spec)
 
 
 class Repository(Object):

--- a/procession/storage/base.py
+++ b/procession/storage/base.py
@@ -119,25 +119,3 @@ class Driver(object):
                 does not exist in backend storage.
         """
         raise NotImplementedError('remove_relation')  # pragma: no cover
-
-    @abc.abstractmethod
-    def get_relations(self, parent_obj_type, child_obj_type,
-                      parent_search_spec, child_search_spec=None):
-        """
-        Returns a list of Python dicts of records of the child type
-        that match the supplied search spec for the parent and
-        child relation types. Used for many-to-many relationship traversal,
-        for instance with user -> group membership.
-
-        :param parent_obj_type: A `procession.objects.Object` class for the
-                                parent side of the relation.
-        :param child_obj_type: A `procession.objects.Object` class for the
-                               child side of the relation.
-        :param parent_search_spec: A `procession.search.SearchSpec` object with
-                                   conditions for the parent side of the
-                                   relation.
-        :param child_search_spec: A `procession.search.SearchSpec` object with
-                                  conditions for the child side of the
-                                  relation.
-        """
-        raise NotImplementedError('get_relations')  # pragma: no cover

--- a/procession/storage/sql/driver.py
+++ b/procession/storage/sql/driver.py
@@ -89,39 +89,6 @@ class Driver(object):
         db_model = api.get_one(sess, model, **filters)
         return db_model.to_dict()
 
-    def get_relations(self, parent_obj_type, child_obj_type,
-                      parent_search_spec, child_search_spec=None):
-        """
-        Returns a list of Python dicts of records of the child type
-        that match the supplied search spec for the parent and
-        child relation types. Used for many-to-many relationship traversal,
-        for instance with user -> group membership.
-
-        :param parent_obj_type: A `procession.objects.Object` class for the
-                                parent side of the relation.
-        :param child_obj_type: A `procession.objects.Object` class for the
-                               child side of the relation.
-        :param parent_search_spec: A `procession.search.SearchSpec` object with
-                                   conditions for the parent side of the
-                                   relation.
-        :param child_search_spec: A `procession.search.SearchSpec` object with
-                                  conditions for the child side of the
-                                  relation.
-        """
-        func_map = {
-            ('user', 'group'): api.user_groups_get
-        }
-        sess = self._get_session()
-        parent_obj_name = parent_obj_type._SINGULAR_NAME
-        child_obj_name = child_obj_type._SINGULAR_NAME
-        map_key = (parent_obj_name, child_obj_name)
-        try:
-            api_fn = func_map[map_key]
-        except KeyError:
-            raise exc.InvalidRelation
-        db_models = api_fn(sess, parent_search_spec, child_search_spec)
-        return [db_model.to_dict() for db_model in db_models]
-
     def get_many(self, obj_type, search_spec):
         """
         Returns a list of Python dicts of records that match the supplied

--- a/procession/store.py
+++ b/procession/store.py
@@ -91,30 +91,6 @@ class Store(object):
         self.driver.remove_relation(parent_obj_type, child_obj_type,
                                     parent_key, child_key)
 
-    def get_relations(self, parent_obj_type, child_obj_type,
-                      parent_search_spec, child_search_spec=None):
-        """
-        Returns a list of Python dicts of records of the child type
-        that match the supplied search spec for the parent and
-        child relation types. Used for many-to-many relationship traversal,
-        for instance with user -> group membership.
-
-        :param parent_obj_type: A `procession.objects.Object` class for the
-                                parent side of the relation.
-        :param child_obj_type: A `procession.objects.Object` class for the
-                               child side of the relation.
-        :param parent_search_spec: A `procession.search.SearchSpec` object with
-                                   conditions for the parent side of the
-                                   relation.
-        :param child_search_spec: A `procession.search.SearchSpec` object with
-                                  conditions for the child side of the
-                                  relation.
-        """
-        return self.driver.get_relations(parent_obj_type,
-                                         child_obj_type,
-                                         parent_search_spec,
-                                         child_search_spec)
-
     def get_many(self, obj_type, search_spec):
         """
         Returns a list of Python dicts of records that match the supplied

--- a/tests/storage/sql/test_driver.py
+++ b/tests/storage/sql/test_driver.py
@@ -113,52 +113,6 @@ class TestSqlDriver(base.UnitTest):
                                          models.Organization,
                                          mock.sentinel.key)
 
-    @mock.patch('procession.storage.sql.driver.Driver._get_session')
-    def test_get_relations_invalid_relation(self, sess_mock):
-        sess_mock.return_value = mock.sentinel.session
-
-        filters = {
-            'name': 'fake-user',
-        }
-        user_search_spec = search.SearchSpec(self.ctx, filters=filters)
-        with testtools.ExpectedException(exc.InvalidRelation):
-            self.driver.get_relations(objects.User, objects.Domain,
-                                      user_search_spec)
-
-    @mock.patch('procession.storage.sql.api.user_groups_get')
-    @mock.patch('procession.storage.sql.driver.Driver._get_session')
-    def test_get_relations(self, sess_mock, api_mock):
-        sess_mock.return_value = mock.sentinel.session
-        db_model_mock = mock.MagicMock()
-        db_model_mock.to_dict.return_value = mock.sentinel.to_dict
-        api_mock.return_value = [db_model_mock]
-
-        filters = {
-            'name': 'fake-user',
-        }
-        user_search_spec = search.SearchSpec(self.ctx, filters=filters)
-        r = self.driver.get_relations(objects.User, objects.Group,
-                                      user_search_spec)
-
-        self.assertEqual([mock.sentinel.to_dict], r)
-        api_mock.assert_called_once_with(mock.sentinel.session,
-                                         user_search_spec,
-                                         None)
-
-        api_mock.reset_mock()
-        filters = {
-            'name': 'fake-group',
-        }
-        group_search_spec = search.SearchSpec(self.ctx, filters=filters)
-        r = self.driver.get_relations(objects.User, objects.Group,
-                                      user_search_spec,
-                                      group_search_spec)
-
-        self.assertEqual([mock.sentinel.to_dict], r)
-        api_mock.assert_called_once_with(mock.sentinel.session,
-                                         user_search_spec,
-                                         group_search_spec)
-
     @mock.patch('procession.storage.sql.api.organization_delete')
     @mock.patch('procession.storage.sql.driver.Driver._get_session')
     def test_delete(self, sess_mock, api_mock):

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -317,12 +317,11 @@ class TestGroup(base.UnitTest):
         group = objects.Group.from_dict(group_dict, ctx=ctx)
         users = group.get_users()
 
-        ctx.store.get_relations.assert_called_once_with(objects.Group,
-                                                        objects.User,
-                                                        mock.ANY)
+        ctx.store.get_many.assert_called_once_with(objects.User,
+                                                   mock.ANY)
         # Check that we have a created search spec argument.
-        _name, args, _kwargs = ctx.store.get_relations.mock_calls[0]
-        search_spec = args[2]
+        _name, args, _kwargs = ctx.store.get_many.mock_calls[0]
+        search_spec = args[1]
         self.assertIsInstance(search_spec, search.SearchSpec)
 
     def test_get_users(self):
@@ -341,13 +340,11 @@ class TestGroup(base.UnitTest):
         search_spec = search.SearchSpec(ctx, filters=filters)
         users = group.get_users(search_spec)
 
-        ctx.store.get_relations.assert_called_once_with(objects.Group,
-                                                        objects.User,
-                                                        search_spec)
+        ctx.store.get_many.assert_called_once_with(objects.User, search_spec)
         # Check that we have a group_id filter set on the supplied search
         # spec argument along with the supplied user name filter.
-        _name, args, _kwargs = ctx.store.get_relations.mock_calls[0]
-        search_spec_arg = args[2]
+        _name, args, _kwargs = ctx.store.get_many.mock_calls[0]
+        search_spec_arg = args[1]
         self.assertIsInstance(search_spec_arg, search.SearchSpec)
         self.assertEqual(2, len(search_spec_arg.filters))
         self.assertIn('group_id', search_spec_arg.filters)
@@ -399,12 +396,10 @@ class TestUser(base.UnitTest):
         user = objects.User.from_dict(user_dict, ctx=ctx)
         groups = user.get_groups()
 
-        ctx.store.get_relations.assert_called_once_with(objects.User,
-                                                        objects.Group,
-                                                        mock.ANY)
+        ctx.store.get_many.assert_called_once_with(objects.Group, mock.ANY)
         # Check that we have a created search spec argument.
-        _name, args, _kwargs = ctx.store.get_relations.mock_calls[0]
-        search_spec = args[2]
+        _name, args, _kwargs = ctx.store.get_many.mock_calls[0]
+        search_spec = args[1]
         self.assertIsInstance(search_spec, search.SearchSpec)
 
     def test_get_groups(self):
@@ -423,13 +418,11 @@ class TestUser(base.UnitTest):
         search_spec = search.SearchSpec(ctx, filters=filters)
         groups = user.get_groups(search_spec)
 
-        ctx.store.get_relations.assert_called_once_with(objects.User,
-                                                        objects.Group,
-                                                        search_spec)
+        ctx.store.get_many.assert_called_once_with(objects.Group, search_spec)
         # Check that we have a group_id filter set on the supplied search
         # spec argument along with the supplied user name filter.
-        _name, args, _kwargs = ctx.store.get_relations.mock_calls[0]
-        search_spec_arg = args[2]
+        _name, args, _kwargs = ctx.store.get_many.mock_calls[0]
+        search_spec_arg = args[1]
         self.assertIsInstance(search_spec_arg, search.SearchSpec)
         self.assertEqual(2, len(search_spec_arg.filters))
         self.assertIn('user_id', search_spec_arg.filters)

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -61,10 +61,6 @@ class FakeDriver(base_storage.Driver):
                                parent_key,
                                child_key))
 
-    def get_relations(self, parent_obj_type, child_obj_type,
-                      parent_search_spec, child_search_spec=None):
-        return mock.sentinel.get_relations
-
 
 class AddFakeStoreDriver(fixtures.Fixture):
     def _setUp(self):
@@ -123,12 +119,6 @@ class TestStoreInterface(base.UnitTest):
         self.assertFalse(self.store_obj.driver.saved)
         self.store_obj.save(mock.sentinel.obj)
         self.assertTrue(self.store_obj.driver.saved)
-
-    def test_get_relations(self):
-        r = self.store_obj.get_relations(mock.sentinel.parent_obj_type,
-                                         mock.sentinel.child_obj_type,
-                                         mock.sentinel.parent_search)
-        self.assertEqual(mock.sentinel.get_relations, r)
 
     def test_modify_relations(self):
         rel_key = (mock.sentinel.parent_obj_type,


### PR DESCRIPTION
The get_relations() method really was not useful. Doing get_many() on the relation
object class is more appropriate and easier to understand.