### PR TITLE
unit-test: Completes unit test coverage for procession.objects

### DIFF
--- a/procession/objects.py
+++ b/procession/objects.py
@@ -584,10 +584,10 @@ class UserPublicKey(Object):
 class Domain(Object):
     _SINGULAR_NAME = 'domain'
     _PLURAL_NAME = 'domains'
-    _FIELD_NAME_TRANSLATIONS = [
-        ('createdOn', 'created_on'),
-        ('ownerId', 'owner_id'),
-    ]
+    _FIELD_NAME_TRANSLATIONS = {
+        'createdOn': 'created_on',
+        'ownerId': 'owner_id',
+    }
     _FIELD_VALUE_TRANSLATORS = {
         'created_on': translators.coerce_iso8601_string,
     }
@@ -595,7 +595,7 @@ class Domain(Object):
 
     def get_repos(self, search_spec=None):
         if search_spec is None:
-            search_spec = search.SearchSpec(ctx=self.ctx)
+            search_spec = search.SearchSpec(self.ctx)
         search_spec.filter_by(domain_id=self.id)
         return Repository.get_many(search_spec)
 

--- a/procession/objects.py
+++ b/procession/objects.py
@@ -550,7 +550,7 @@ class User(Object):
 
     def get_public_keys(self, search_spec=None):
         if search_spec is None:
-            search_spec = search.SearchSpec(ctx=self.ctx)
+            search_spec = search.SearchSpec(self.ctx)
         search_spec.filter_by(user_id=self.id)
         return UserPublicKey.get_many(search_spec)
 

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -507,3 +507,51 @@ class TestUser(base.UnitTest):
                                                           six.b(mocks.UUID1),
                                                           objects.Group,
                                                           mocks.UUID2)
+
+
+class TestDomain(base.UnitTest):
+    def test_get_repos_no_supplied_search(self):
+        ctx = context.Context()
+        ctx.store = mock.MagicMock()
+
+        domain_dict = {
+            'id': mocks.UUID1,
+            'name': 'My domain'
+        }
+        domain = objects.Domain.from_dict(domain_dict, ctx=ctx)
+        repos = domain.get_repos()
+
+        ctx.store.get_many.assert_called_once_with(objects.Repository,
+                                                   mock.ANY)
+        # Check that we have a created search spec argument.
+        _name, args, _kwargs = ctx.store.get_many.mock_calls[0]
+        search_spec = args[1]
+        self.assertIsInstance(search_spec, search.SearchSpec)
+
+    def test_get_repos(self):
+        ctx = context.Context()
+        ctx.store = mock.MagicMock()
+
+        domain_dict = {
+            'id': mocks.UUID1,
+            'name': 'My domain'
+        }
+        domain = objects.Domain.from_dict(domain_dict, ctx=ctx)
+
+        filters = {
+            'name': 'My repo',
+        }
+        search_spec = search.SearchSpec(ctx, filters=filters)
+        repos = domain.get_repos(search_spec)
+
+        ctx.store.get_many.assert_called_once_with(objects.Repository,
+                                                   search_spec)
+        # Check that we have a repo_id filter set on the supplied search
+        # spec argument along with the supplied domain name filter.
+        _name, args, _kwargs = ctx.store.get_many.mock_calls[0]
+        search_spec_arg = args[1]
+        self.assertIsInstance(search_spec_arg, search.SearchSpec)
+        self.assertEqual(2, len(search_spec_arg.filters))
+        self.assertIn('domain_id', search_spec_arg.filters)
+        self.assertIn('name', search_spec_arg.filters)
+        self.assertEqual('My repo', search_spec_arg.filters['name'])

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -385,6 +385,53 @@ class TestGroup(base.UnitTest):
 
 
 class TestUser(base.UnitTest):
+    def test_get_public_keys_no_supplied_search(self):
+        ctx = context.Context()
+        ctx.store = mock.MagicMock()
+
+        user_dict = {
+            'id': mocks.UUID1,
+            'name': 'My user'
+        }
+        user = objects.User.from_dict(user_dict, ctx=ctx)
+        public_keys = user.get_public_keys()
+
+        ctx.store.get_many.assert_called_once_with(objects.UserPublicKey,
+                                                   mock.ANY)
+        # Check that we have a created search spec argument.
+        _name, args, _kwargs = ctx.store.get_many.mock_calls[0]
+        search_spec = args[1]
+        self.assertIsInstance(search_spec, search.SearchSpec)
+
+    def test_get_public_keys(self):
+        ctx = context.Context()
+        ctx.store = mock.MagicMock()
+
+        user_dict = {
+            'id': mocks.UUID1,
+            'name': 'My user'
+        }
+        user = objects.User.from_dict(user_dict, ctx=ctx)
+
+        filters = {
+            'fingerprint': mocks.FINGERPRINT1,
+        }
+        search_spec = search.SearchSpec(ctx, filters=filters)
+        public_keys = user.get_public_keys(search_spec)
+
+        ctx.store.get_many.assert_called_once_with(objects.UserPublicKey,
+                                                   search_spec)
+        # Check that we have a public_key_id filter set on the supplied search
+        # spec argument along with the supplied user name filter.
+        _name, args, _kwargs = ctx.store.get_many.mock_calls[0]
+        search_spec_arg = args[1]
+        self.assertIsInstance(search_spec_arg, search.SearchSpec)
+        self.assertEqual(2, len(search_spec_arg.filters))
+        self.assertIn('user_id', search_spec_arg.filters)
+        self.assertIn('fingerprint', search_spec_arg.filters)
+        self.assertEqual(mocks.FINGERPRINT1,
+                         search_spec_arg.filters['fingerprint'])
+
     def test_get_groups_no_supplied_search(self):
         ctx = context.Context()
         ctx.store = mock.MagicMock()


### PR DESCRIPTION
Adds tests for User.get_public_keys() and Domain.get_repos()